### PR TITLE
add aria-current attribute for accessibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.2', '7.4', '5.5', '8.0', '8.1']
+        php-versions: ['7.2', '7.4', '8.0', '8.1']
 
     name: PHP ${{ matrix.php-versions }} Test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
+        php-versions: ['7.2', '7.4', '5.5', '8.0', '8.1']
 
     name: PHP ${{ matrix.php-versions }} Test
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The breadcrumb package helps to integrate a common breadcrumb navigation into a 
 
 ### Compatibility
 
-* PHP5.3+
+* PHP7.2+
 
 ### Dependencies
 

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=8.1.0",
         "naucon/utility": "~1.1",
         "naucon/htmlbuilder": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8"
+        "phpunit/phpunit": "^8.0"
     },
     "autoload": {
         "psr-4": {"Naucon\\Breadcrumbs\\": "src/"}

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
+        "php": ">=5.3.0",
         "naucon/utility": "~1.1",
         "naucon/htmlbuilder": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~8.0"
+        "phpunit/phpunit": "~4.8"
     },
     "autoload": {
         "psr-4": {"Naucon\\Breadcrumbs\\": "src/"}

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=8.1.0",
+        "php": "<=8.1.0",
         "naucon/utility": "~1.1",
         "naucon/htmlbuilder": "~1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "<=8.1.0",
+        "php": ">=7.2.0",
         "naucon/utility": "~1.1",
         "naucon/htmlbuilder": "~1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=7.2",
         "naucon/utility": "~1.1",
         "naucon/htmlbuilder": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8"
+        "phpunit/phpunit": "~8.0"
     },
     "autoload": {
         "psr-4": {"Naucon\\Breadcrumbs\\": "src/"}

--- a/src/Handler/BreadcrumbHandlerAbstract.php
+++ b/src/Handler/BreadcrumbHandlerAbstract.php
@@ -43,7 +43,7 @@ abstract class BreadcrumbHandlerAbstract implements BreadcrumbHandlerInterface
     /**
      * @return      IteratorInterface
      */
-    public function getIterator()
+    public function getIterator(): IteratorInterface
     {
         return $this->getBreadcrumbCollection()->getIterator();
     }
@@ -70,7 +70,7 @@ abstract class BreadcrumbHandlerAbstract implements BreadcrumbHandlerInterface
     /**
      * @return      int         amount of breadcrumbs
      */
-    public function count()
+    public function count(): int
     {
         return $this->getBreadcrumbCollection()->count();
     }

--- a/src/Handler/BreadcrumbHandlerInterface.php
+++ b/src/Handler/BreadcrumbHandlerInterface.php
@@ -24,7 +24,7 @@ interface BreadcrumbHandlerInterface extends IteratorAwareInterface
     /**
      * @return      IteratorInterface
      */
-    public function getIterator();
+    public function getIterator(): IteratorInterface;
 
     /**
      * @return      IteratorInterface
@@ -42,7 +42,7 @@ interface BreadcrumbHandlerInterface extends IteratorAwareInterface
     /**
      * @return      int         amount of breadcrumbs
      */
-    public function count();
+    public function count(): int;
 
     /**
      * clear breadcrumb

--- a/src/Helper/BreadcrumbsHelper.php
+++ b/src/Helper/BreadcrumbsHelper.php
@@ -203,12 +203,20 @@ class BreadcrumbsHelper extends BreadcrumbsHelperAbstract
         return $this;
     }
 
-    private function isCurrentPage(int $i, int $lastElementIndex): bool
+    private function setAriaLabelforCurrentPage(array $breadcrumbsItems): array
     {
-        if ((!$this->isReverse() && $i == $lastElementIndex) || ($this->isReverse() && $i == 0)) {
-            return true;
+        $currentPageIndex = $this->isReverse() ? 0 : count($breadcrumbsItems) - 1;
+
+        $currentPage = $breadcrumbsItems[$currentPageIndex];
+
+        if ($currentPage instanceof HtmlElementUniversalAbstract) {
+            $currentPage->setAttribute('aria-current', 'page');
+        } else {
+            $currentPage = new HtmlSpan($currentPage);
+            $currentPage->setAttribute('aria-current', 'page');
         }
-        return false;
+        $breadcrumbsItems[$currentPageIndex] = $currentPage;
+        return $breadcrumbsItems;
     }
 
     /**
@@ -224,9 +232,7 @@ class BreadcrumbsHelper extends BreadcrumbsHelperAbstract
             $breadcrumbIterator = $this->getBreadcrumbs()->getIterator();
         }
 
-        $breadcrumbsItems = array();
-        $i = 0;
-        $lastElementIndex = count($breadcrumbIterator)-1;
+        $breadcrumbsItems = [];
         foreach ($breadcrumbIterator as $breadcrumbObject) {
             if (!$this->hasSkipLinks() && $breadcrumbObject->hasUrl()) {
                 $breadcrumbInner = new HtmlAnchor($breadcrumbObject->getUrl(), $breadcrumbObject->getTitle());
@@ -251,18 +257,9 @@ class BreadcrumbsHelper extends BreadcrumbsHelperAbstract
                     break;
             }
 
-                if ($this->isCurrentPage($i, $lastElementIndex)) {
-                    if ($breadcrumbOuter instanceof HtmlElementUniversalAbstract) {
-                        $breadcrumbOuter->setAttribute('aria-current', 'page');
-                    } else {
-                        $breadcrumbOuter = new HtmlSpan($breadcrumbOuter);
-                        $breadcrumbOuter->setAttribute('aria-current', 'page');
-                    }
-                }
-
             $breadcrumbsItems[] = $breadcrumbOuter;
-            $i++;
         }
+        $breadcrumbsItems = $this->setAriaLabelforCurrentPage($breadcrumbsItems);
 
         // surround breadcrumb string a container, depending on the tag
         switch ($this->getTag()) {

--- a/src/Helper/BreadcrumbsHelper.php
+++ b/src/Helper/BreadcrumbsHelper.php
@@ -222,14 +222,8 @@ class BreadcrumbsHelper extends BreadcrumbsHelperAbstract
         foreach ($breadcrumbIterator as $breadcrumbObject) {
             if (!$this->hasSkipLinks() && $breadcrumbObject->hasUrl()) {
                 $breakcrumbInner = new HtmlAnchor($breadcrumbObject->getUrl(), $breadcrumbObject->getTitle());
-                if (!$this->isReverse()) {
-                    if ($lastBreadcrumb === $breadcrumbObject) {
-                        $breakcrumbInner = $breakcrumbInner->setAttribute('aria-current', 'page');
-                    }
-                } else {
-                    if ($firstBreadcrumb === $breadcrumbObject) {
-                        $breakcrumbInner = $breakcrumbInner->setAttribute('aria-current', 'page');
-                    }
+                if ((!$this->isReverse() && $lastBreadcrumb === $breadcrumbObject) || ($this->isReverse() && $firstBreadcrumb === $breadcrumbObject)) {
+                    $breakcrumbInner->setAttribute('aria-current', 'page');
                 }
             } else {
                 $breakcrumbInner = $breadcrumbObject->getTitle();

--- a/src/Helper/BreadcrumbsHelper.php
+++ b/src/Helper/BreadcrumbsHelper.php
@@ -216,9 +216,21 @@ class BreadcrumbsHelper extends BreadcrumbsHelperAbstract
         }
 
         $breakcrumbsItems = array();
+        $breadcrumbsArray = iterator_to_array($breadcrumbIterator);
+        $lastBreadcrumb = end($breadcrumbsArray);
+        $firstBreadcrumb = $breadcrumbsArray[0];
         foreach ($breadcrumbIterator as $breadcrumbObject) {
             if (!$this->hasSkipLinks() && $breadcrumbObject->hasUrl()) {
                 $breakcrumbInner = new HtmlAnchor($breadcrumbObject->getUrl(), $breadcrumbObject->getTitle());
+                if (!$this->isReverse()) {
+                    if ($lastBreadcrumb === $breadcrumbObject) {
+                        $breakcrumbInner = $breakcrumbInner->setAttribute('aria-current', 'page');
+                    }
+                } else {
+                    if ($firstBreadcrumb === $breadcrumbObject) {
+                        $breakcrumbInner = $breakcrumbInner->setAttribute('aria-current', 'page');
+                    }
+                }
             } else {
                 $breakcrumbInner = $breadcrumbObject->getTitle();
             }

--- a/src/Helper/BreadcrumbsHelper.php
+++ b/src/Helper/BreadcrumbsHelper.php
@@ -216,15 +216,11 @@ class BreadcrumbsHelper extends BreadcrumbsHelperAbstract
         }
 
         $breakcrumbsItems = array();
-        $breadcrumbsArray = iterator_to_array($breadcrumbIterator);
-        $lastBreadcrumb = end($breadcrumbsArray);
-        $firstBreadcrumb = $breadcrumbsArray[0];
+        $i = 0;
+        $lastElementIndex = count($breadcrumbIterator)-1;
         foreach ($breadcrumbIterator as $breadcrumbObject) {
             if (!$this->hasSkipLinks() && $breadcrumbObject->hasUrl()) {
                 $breakcrumbInner = new HtmlAnchor($breadcrumbObject->getUrl(), $breadcrumbObject->getTitle());
-                if ((!$this->isReverse() && $lastBreadcrumb === $breadcrumbObject) || ($this->isReverse() && $firstBreadcrumb === $breadcrumbObject)) {
-                    $breakcrumbInner->setAttribute('aria-current', 'page');
-                }
             } else {
                 $breakcrumbInner = $breadcrumbObject->getTitle();
             }
@@ -245,7 +241,25 @@ class BreadcrumbsHelper extends BreadcrumbsHelperAbstract
                     $breadcrumbOuter = $breakcrumbInner;
                     break;
             }
+
+            if (is_object($breadcrumbOuter) && method_exists($breadcrumbOuter, 'setAttribute')) {
+                if ($breadcrumbOuter->hasChildElements()) {
+                    $childElementCollection = $breadcrumbOuter->getChildElementCollection();
+                    $childElements = $childElementCollection->toArray();
+                    if (count($childElements) > 1) {
+                        $childElement = $childElements[0];
+                        if ((!$this->isReverse() && $i == $lastElementIndex) || ($this->isReverse() && $i == 0)) {
+                            $childElement->setAttribute('aria-current', 'page');
+                        }
+                    } elseif (!$breadcrumbObject->hasUrl() &&
+                    (!$this->isReverse() && $i == $lastElementIndex) ||
+                    ($this->isReverse() && $i == 0)) {
+                        $breadcrumbOuter->setAttribute('aria-current', 'page');
+                    }
+                }
+            }
             $breakcrumbsItems[] = $breadcrumbOuter;
+            $i++;
         }
 
         // surround breadcrumb string a container, depending on the tag

--- a/src/Helper/BreadcrumbsHelper.php
+++ b/src/Helper/BreadcrumbsHelper.php
@@ -242,14 +242,17 @@ class BreadcrumbsHelper extends BreadcrumbsHelperAbstract
                     break;
             }
 
+            $childElementsArr = array();
             if (is_object($breadcrumbOuter) && method_exists($breadcrumbOuter, 'setAttribute')) {
                 if ($breadcrumbOuter->hasChildElements()) {
                     $childElementCollection = $breadcrumbOuter->getChildElementCollection();
                     $childElements = $childElementCollection->toArray();
-                    if (count($childElements) > 1) {
-                        $childElement = $childElements[0];
+                    $childElement = $childElements[0];
+                    if ($childElement->hasChildElements()) {
                         if ((!$this->isReverse() && $i == $lastElementIndex) || ($this->isReverse() && $i == 0)) {
                             $childElement->setAttribute('aria-current', 'page');
+                            $childElementsArr[] = $childElement;
+                            $breadcrumbOuter->setChildElements($childElementsArr);
                         }
                     } elseif (!$breadcrumbObject->hasUrl() &&
                     (!$this->isReverse() && $i == $lastElementIndex) ||

--- a/src/Helper/BreadcrumbsHelper.php
+++ b/src/Helper/BreadcrumbsHelper.php
@@ -248,15 +248,17 @@ class BreadcrumbsHelper extends BreadcrumbsHelperAbstract
                     $childElementCollection = $breadcrumbOuter->getChildElementCollection();
                     $childElements = $childElementCollection->toArray();
                     $childElement = $childElements[0];
-                    if ($childElement->hasChildElements()) {
-                        if ((!$this->isReverse() && $i == $lastElementIndex) || ($this->isReverse() && $i == 0)) {
-                            $childElement->setAttribute('aria-current', 'page');
-                            $childElementsArr[] = $childElement;
-                            $breadcrumbOuter->setChildElements($childElementsArr);
+                    if (is_object($childElement) && method_exists($childElement, 'hasChildElements')) {
+                        if ($childElement->hasChildElements()) {
+                            if ((!$this->isReverse() && $i == $lastElementIndex) || ($this->isReverse() && $i == 0)) {
+                                $childElement->setAttribute('aria-current', 'page');
+                                $childElementsArr[] = $childElement;
+                                $breadcrumbOuter->setChildElements($childElementsArr);
+                            }
                         }
                     } elseif (!$breadcrumbObject->hasUrl() &&
-                    (!$this->isReverse() && $i == $lastElementIndex) ||
-                    ($this->isReverse() && $i == 0)) {
+                        (!$this->isReverse() && $i == $lastElementIndex) ||
+                        ($this->isReverse() && $i == 0)) {
                         $breadcrumbOuter->setAttribute('aria-current', 'page');
                     }
                 }

--- a/src/Helper/BreadcrumbsHelper.php
+++ b/src/Helper/BreadcrumbsHelper.php
@@ -202,6 +202,14 @@ class BreadcrumbsHelper extends BreadcrumbsHelperAbstract
         return $this;
     }
 
+    private function isLastItem(HtmlAnchor|HtmlDiv|HtmlListItem|HtmlSpan $breadcrumbOuter, int $i, int $lastElementIndex): bool
+    {
+        if ((!$this->isReverse() && $i == $lastElementIndex) || ($this->isReverse() && $i == 0)) {
+            return true;
+        }
+        return false;
+    }
+
     /**
      * @return        string                    html output
      */
@@ -241,28 +249,16 @@ class BreadcrumbsHelper extends BreadcrumbsHelperAbstract
                     $breadcrumbOuter = $breakcrumbInner;
                     break;
             }
-
-            $childElementsArr = array();
-            if (is_object($breadcrumbOuter) && method_exists($breadcrumbOuter, 'setAttribute')) {
-                if ($breadcrumbOuter->hasChildElements()) {
-                    $childElementCollection = $breadcrumbOuter->getChildElementCollection();
-                    $childElements = $childElementCollection->toArray();
-                    $childElement = $childElements[0];
-                    if (is_object($childElement) && method_exists($childElement, 'hasChildElements')) {
-                        if ($childElement->hasChildElements()) {
-                            if ((!$this->isReverse() && $i == $lastElementIndex) || ($this->isReverse() && $i == 0)) {
-                                $childElement->setAttribute('aria-current', 'page');
-                                $childElementsArr[] = $childElement;
-                                $breadcrumbOuter->setChildElements($childElementsArr);
-                            }
-                        }
-                    } elseif (!$breadcrumbObject->hasUrl() &&
-                        (!$this->isReverse() && $i == $lastElementIndex) ||
-                        ($this->isReverse() && $i == 0)) {
+            switch (gettype($breadcrumbOuter)) {
+                case 'string':
+                    break;
+                default:
+                    if ($this->isLastItem($breadcrumbOuter, $i, $lastElementIndex)) {
                         $breadcrumbOuter->setAttribute('aria-current', 'page');
                     }
-                }
+                    break;
             }
+
             $breakcrumbsItems[] = $breadcrumbOuter;
             $i++;
         }

--- a/tests/BreadcrumbHandlerSessionTest.php
+++ b/tests/BreadcrumbHandlerSessionTest.php
@@ -10,74 +10,56 @@
 namespace Naucon\Breadcrumbs\Tests;
 
 use Naucon\Breadcrumbs\Breadcrumb;
+use Naucon\Breadcrumbs\BreadcrumbInterface;
 use Naucon\Breadcrumbs\Handler\BreadcrumbHandlerInterface;
 use Naucon\Breadcrumbs\Handler\BreadcrumbHandlerSession;
 use PHPUnit\Framework\TestCase;
 
 class BreadcrumbHandlerSessionTest extends TestCase
 {
-    public static $sessionData = array();
+    public static $sessionData = [];
 
-    public function setUp(): void
+    /**
+     * @param BreadcrumbHandlerSession $breadcrumbHandler
+     */
+    private $breadcrumbHandler;
+
+    public function setUp():void
     {
         $_SESSION = self::$sessionData;
+        $this->breadcrumbHandler = new BreadcrumbHandlerSession();
+        $this->prepareBreadcrumbs();
     }
 
     public function tearDown(): void
     {
+        $this->breadcrumbHandler->clear();
         self::$sessionData = $_SESSION;
     }
 
-    /**
-     * @return      BreadcrumbHandlerInterface
-     */
-    public function testInit()
+    public function prepareBreadcrumbs(): void
     {
-        $breadcrumbHandler = new BreadcrumbHandlerSession();
-        return $breadcrumbHandler;
+        $this->breadcrumbHandler->add(new Breadcrumb('home', '/home/'));
+        $this->breadcrumbHandler->add(new Breadcrumb('profile', '/profile/'));
+        $this->breadcrumbHandler->add(new Breadcrumb('address'));
     }
 
-    /**
-     * @depends     testInit
-     * @param       BreadcrumbHandlerInterface      $breadcrumbHandler
-     * @return      BreadcrumbHandlerInterface
-     */
-    public function testAdd(BreadcrumbHandlerInterface $breadcrumbHandler)
-    {
-        $breadcrumbHandler->add(new Breadcrumb('home', '/home/'));
-        $breadcrumbHandler->add(new Breadcrumb('profile', '/profile/'));
-        $breadcrumbHandler->add(new Breadcrumb('address'));
-
-        return $breadcrumbHandler;
-    }
-
-    /**
-     * @depends     testAdd
-     * @param       BreadcrumbHandlerInterface      $breadcrumbHandler
-     * @return      BreadcrumbHandlerInterface
-     */
-    public function testCount(BreadcrumbHandlerInterface $breadcrumbHandler)
+    public function testCount(): void
     {
         $expectedSessionNamespace = '__NcBreadcrumbStorage';
 
-        $this->assertEquals(3, $breadcrumbHandler->count());
+        echo $this->breadcrumbHandler->count();
+        $this->assertEquals(3, $this->breadcrumbHandler->count());
         $this->assertCount(3, $_SESSION[$expectedSessionNamespace]);
-
-        return $breadcrumbHandler;
     }
 
-    /**
-     * @depends     testAdd
-     * @param       BreadcrumbHandlerInterface      $breadcrumbHandler
-     * @return      BreadcrumbHandlerInterface
-     */
-    public function testIterator(BreadcrumbHandlerInterface $breadcrumbHandler)
+    public function testIterator(): void
     {
         $expectedSessionNamespace = '__NcBreadcrumbStorage';
 
-        $breadcrumbIterator = $breadcrumbHandler->getIterator();
+        $breadcrumbIterator = $this->breadcrumbHandler->getIterator();
 
-        $expectedBreadcrumbs = array();
+        $expectedBreadcrumbs = [];
         $expectedBreadcrumbs[0]['title'] = 'home';
         $expectedBreadcrumbs[0]['url'] = '/home/';
         $expectedBreadcrumbs[1]['title'] = 'profile';
@@ -95,22 +77,15 @@ class BreadcrumbHandlerSessionTest extends TestCase
         $this->assertEquals(3, $i);
 
         $this->assertEquals($expectedBreadcrumbs, $_SESSION[$expectedSessionNamespace]);
-
-        return $breadcrumbHandler;
     }
 
-    /**
-     * @depends     testAdd
-     * @param       BreadcrumbHandlerInterface      $breadcrumbHandler
-     * @return      BreadcrumbHandlerInterface
-     */
-    public function testReverseIterator(BreadcrumbHandlerInterface $breadcrumbHandler)
+    public function testReverseIterator(): void
     {
         $expectedSessionNamespace = '__NcBreadcrumbStorage';
 
-        $breadcrumbIterator = $breadcrumbHandler->getReverseIterator();
+        $breadcrumbIterator = $this->breadcrumbHandler->getReverseIterator();
 
-        $expectedBreadcrumbs = array();
+        $expectedBreadcrumbs = [];
         $expectedBreadcrumbs[0]['title'] = 'address';
         $expectedBreadcrumbs[0]['url'] = null;
         $expectedBreadcrumbs[1]['title'] = 'profile';
@@ -126,27 +101,18 @@ class BreadcrumbHandlerSessionTest extends TestCase
             $i++;
         }
         $this->assertEquals(3, $i);
-
-        return $breadcrumbHandler;
     }
 
-    /**
-     * @depends     testAdd
-     * @param       BreadcrumbsInterface        $breadcrumbHandler
-     * @return      BreadcrumbsInterface
-     */
-    public function testClear(BreadcrumbHandlerInterface $breadcrumbHandler)
+    public function testClear(): void
     {
         $expectedSessionNamespace = '__NcBreadcrumbStorage';
 
-        $this->assertEquals(3, $breadcrumbHandler->count());
+        $this->assertEquals(3, $this->breadcrumbHandler->count());
         $this->assertCount(3, $_SESSION[$expectedSessionNamespace]);
 
-        $breadcrumbHandler->clear();
+        $this->breadcrumbHandler->clear();
 
-        $this->assertEquals(0, $breadcrumbHandler->count());
+        $this->assertEquals(0, $this->breadcrumbHandler->count());
         $this->assertCount(0, $_SESSION[$expectedSessionNamespace]);
-
-        return $breadcrumbHandler;
     }
 }

--- a/tests/BreadcrumbHandlerSessionTest.php
+++ b/tests/BreadcrumbHandlerSessionTest.php
@@ -12,17 +12,18 @@ namespace Naucon\Breadcrumbs\Tests;
 use Naucon\Breadcrumbs\Breadcrumb;
 use Naucon\Breadcrumbs\Handler\BreadcrumbHandlerInterface;
 use Naucon\Breadcrumbs\Handler\BreadcrumbHandlerSession;
+use PHPUnit\Framework\TestCase;
 
-class BreadcrumbHandlerSessionTest extends \PHPUnit_Framework_TestCase
+class BreadcrumbHandlerSessionTest extends TestCase
 {
     public static $sessionData = array();
 
-    public function setUp()
+    public function setUp(): void
     {
         $_SESSION = self::$sessionData;
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         self::$sessionData = $_SESSION;
     }

--- a/tests/BreadcrumbsHelperTest.php
+++ b/tests/BreadcrumbsHelperTest.php
@@ -12,7 +12,9 @@ namespace Naucon\Breadcrumbs\Tests;
 use Naucon\Breadcrumbs\Breadcrumbs;
 use Naucon\Breadcrumbs\Helper\BreadcrumbsHelper;
 
-class BreadcrumbsHelperTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class BreadcrumbsHelperTest extends TestCase
 {
     /**
      * @return      Breadcrumbs
@@ -253,7 +255,7 @@ class BreadcrumbsHelperTest extends \PHPUnit_Framework_TestCase
         $breadcrumbsHelper->setReverse(true);
         $breadcrumbsHelper->setTag('ol');
 
-        $string = '<ol><li>address</li><li><a href="/profile/">profile</a></li><li><a href="/home/">home</a></li></ol>';
+        $string = '<ol><li>address</li><li><a href="/profile/" aria-current="page">profile</a></li><li><a href="/home/">home</a></li></ol>';
         $this->assertEquals($string, $breadcrumbsHelper->render());
     }
 

--- a/tests/BreadcrumbsHelperTest.php
+++ b/tests/BreadcrumbsHelperTest.php
@@ -47,20 +47,6 @@ class BreadcrumbsHelperTest extends TestCase
         $this->assertEquals($string, $breadcrumbsHelper->render());
     }
 
-    public function testRenderIfLastElementIsLink(): void
-    {
-        $testBreadcrumbs = new Breadcrumbs();
-        $testBreadcrumbs->add('home', '/home/');
-        $testBreadcrumbs->add('profile', '/profile/');
-        $testBreadcrumbs->add('address', '/address/');
-
-        $breadcrumbsHelper = new BreadcrumbsHelper($testBreadcrumbs);
-        $breadcrumbsHelper->setTag('ul');
-
-        $string = '<ul><li><a href="/home/">home</a></li><li><a href="/profile/">profile</a></li><li><a href="/address/" aria-current="page">address</a></li></ul>';
-        $this->assertEquals($string, $breadcrumbsHelper->render());
-    }
-
     public function testRenderWithSeparator(): void
     {
         $breadcrumbsHelper = new BreadcrumbsHelper($this->breadcrumbs);

--- a/tests/BreadcrumbsHelperTest.php
+++ b/tests/BreadcrumbsHelperTest.php
@@ -43,7 +43,7 @@ class BreadcrumbsHelperTest extends TestCase
     {
         $breadcrumbsHelper = new BreadcrumbsHelper($this->breadcrumbs);
 
-        $string = '<a href="/home/">home</a><a href="/profile/">profile</a>address';
+        $string = '<a href="/home/">home</a><a href="/profile/">profile</a><span aria-current="page">address</span>';
         $this->assertEquals($string, $breadcrumbsHelper->render());
     }
 
@@ -53,7 +53,7 @@ class BreadcrumbsHelperTest extends TestCase
         $breadcrumbsHelper->setSeparator(' / ');
         $test = $breadcrumbsHelper->isReverse();
 
-        $string = '<a href="/home/">home</a> / <a href="/profile/">profile</a> / address';
+        $string = '<a href="/home/">home</a> / <a href="/profile/">profile</a> / <span aria-current="page">address</span>';
         $this->assertEquals($string, $breadcrumbsHelper->render());
     }
 
@@ -127,7 +127,7 @@ class BreadcrumbsHelperTest extends TestCase
         $breadcrumbsHelper = new BreadcrumbsHelper($this->breadcrumbs);
         $breadcrumbsHelper->setReverse(true);
 
-        $string = 'address<a href="/profile/">profile</a><a href="/home/">home</a>';
+        $string = '<span aria-current="page">address</span><a href="/profile/">profile</a><a href="/home/">home</a>';
         $this->assertEquals($string, $breadcrumbsHelper->render());
     }
 
@@ -137,7 +137,7 @@ class BreadcrumbsHelperTest extends TestCase
         $breadcrumbsHelper->setSeparator(' / ');
         $breadcrumbsHelper->setReverse(true);
 
-        $string = 'address / <a href="/profile/">profile</a> / <a href="/home/">home</a>';
+        $string = '<span aria-current="page">address</span> / <a href="/profile/">profile</a> / <a href="/home/">home</a>';
         $this->assertEquals($string, $breadcrumbsHelper->render());
     }
 
@@ -219,7 +219,7 @@ class BreadcrumbsHelperTest extends TestCase
         $breadcrumbsHelper->setSkipLinks(true);
         $breadcrumbsHelper->setSeparator(' / ');
 
-        $string = 'home / profile / address';
+        $string = 'home / profile / <span aria-current="page">address</span>';
         $this->assertEquals($string, $breadcrumbsHelper->render());
     }
 
@@ -230,7 +230,7 @@ class BreadcrumbsHelperTest extends TestCase
         $breadcrumbsHelper->setSkipLinks(true);
         $breadcrumbsHelper->setSeparator(' / ');
 
-        $string = 'address / profile / home';
+        $string = '<span aria-current="page">address</span> / profile / home';
         $this->assertEquals($string, $breadcrumbsHelper->render());
     }
 }

--- a/tests/BreadcrumbsHelperTest.php
+++ b/tests/BreadcrumbsHelperTest.php
@@ -17,166 +17,123 @@ use PHPUnit\Framework\TestCase;
 class BreadcrumbsHelperTest extends TestCase
 {
     /**
-     * @return      Breadcrumbs
+     * @param Breadcrumbs $breadcrumbs
      */
-    public function testInitBreadcrumbs()
+    private $breadcrumbs;
+
+    public function setUp(): void
     {
-        $breadcrumbs = new Breadcrumbs();
-        $breadcrumbs->add('home', '/home/');
-        $breadcrumbs->add('profile', '/profile/');
-        $breadcrumbs->add('address');
-        return $breadcrumbs;
+        $this->breadcrumbs = new Breadcrumbs();
+        $this->prepareBreadcrumbs();
     }
 
-    /**
-     * @depends     testInitBreadcrumbs
-     * @param       Breadcrumbs     $breadcrumbs
-     * @return      void
-     */
-    public function testRender(Breadcrumbs $breadcrumbs)
+    public function tearDown(): void
     {
-        $breadcrumbsHelper = new BreadcrumbsHelper($breadcrumbs);
+        $this->breadcrumbs->clear();
+    }
+
+    public function prepareBreadcrumbs(): void
+    {
+        $this->breadcrumbs->add('home', '/home/');
+        $this->breadcrumbs->add('profile', '/profile/');
+        $this->breadcrumbs->add('address');
+    }
+
+    public function testRender(): void
+    {
+        $breadcrumbsHelper = new BreadcrumbsHelper($this->breadcrumbs);
 
         $string = '<a href="/home/">home</a><a href="/profile/">profile</a>address';
         $this->assertEquals($string, $breadcrumbsHelper->render());
     }
 
-    /**
-     * @depends     testInitBreadcrumbs
-     * @param       Breadcrumbs     $breadcrumbs
-     * @return      void
-     */
-    public function testRenderWithSeparator(Breadcrumbs $breadcrumbs)
+    public function testRenderWithSeparator(): void
     {
-        $breadcrumbsHelper = new BreadcrumbsHelper($breadcrumbs);
+        $breadcrumbsHelper = new BreadcrumbsHelper($this->breadcrumbs);
         $breadcrumbsHelper->setSeparator(' / ');
+        $test = $breadcrumbsHelper->isReverse();
 
         $string = '<a href="/home/">home</a> / <a href="/profile/">profile</a> / address';
         $this->assertEquals($string, $breadcrumbsHelper->render());
     }
 
-    /**
-     * @depends     testInitBreadcrumbs
-     * @param       Breadcrumbs     $breadcrumbs
-     * @return      void
-     */
-    public function testRenderWithSpanTag(Breadcrumbs $breadcrumbs)
+    public function testRenderWithSpanTag(): void
     {
-        $breadcrumbsHelper = new BreadcrumbsHelper($breadcrumbs);
+        $breadcrumbsHelper = new BreadcrumbsHelper($this->breadcrumbs);
         $breadcrumbsHelper->setTag('span');
 
-        $string = '<span><a href="/home/">home</a></span><span><a href="/profile/">profile</a></span><span>address</span>';
+        $string = '<span><a href="/home/">home</a></span><span><a href="/profile/">profile</a></span><span aria-current="page">address</span>';
         $this->assertEquals($string, $breadcrumbsHelper->render());
     }
 
-    /**
-     * @depends     testInitBreadcrumbs
-     * @param       Breadcrumbs     $breadcrumbs
-     * @return      void
-     */
-    public function testRenderWithDivTag(Breadcrumbs $breadcrumbs)
+    public function testRenderWithDivTag(): void
     {
-        $breadcrumbsHelper = new BreadcrumbsHelper($breadcrumbs);
+        $breadcrumbsHelper = new BreadcrumbsHelper($this->breadcrumbs);
         $breadcrumbsHelper->setTag('div');
 
-        $string = '<div><a href="/home/">home</a></div><div><a href="/profile/">profile</a></div><div>address</div>';
+        $string = '<div><a href="/home/">home</a></div><div><a href="/profile/">profile</a></div><div aria-current="page">address</div>';
         $this->assertEquals($string, $breadcrumbsHelper->render());
     }
 
-    /**
-     * @depends     testInitBreadcrumbs
-     * @param       Breadcrumbs     $breadcrumbs
-     * @return      void
-     */
-    public function testRenderWithListItemTag(Breadcrumbs $breadcrumbs)
+    public function testRenderWithListItemTag(): void
     {
-        $breadcrumbsHelper = new BreadcrumbsHelper($breadcrumbs);
+        $breadcrumbsHelper = new BreadcrumbsHelper($this->breadcrumbs);
         $breadcrumbsHelper->setTag('li');
 
-        $string = '<li><a href="/home/">home</a></li><li><a href="/profile/">profile</a></li><li>address</li>';
+        $string = '<li><a href="/home/">home</a></li><li><a href="/profile/">profile</a></li><li aria-current="page">address</li>';
         $this->assertEquals($string, $breadcrumbsHelper->render());
     }
 
-    /**
-     * @depends     testInitBreadcrumbs
-     * @param       Breadcrumbs     $breadcrumbs
-     * @return      void
-     */
-    public function testRenderWithUnorderedListTag(Breadcrumbs $breadcrumbs)
+    public function testRenderWithUnorderedListTag(): void
     {
-        $breadcrumbsHelper = new BreadcrumbsHelper($breadcrumbs);
+        $breadcrumbsHelper = new BreadcrumbsHelper($this->breadcrumbs);
         $breadcrumbsHelper->setTag('ul');
 
-        $string = '<ul><li><a href="/home/">home</a></li><li><a href="/profile/">profile</a></li><li>address</li></ul>';
+        $string = '<ul><li><a href="/home/">home</a></li><li><a href="/profile/">profile</a></li><li aria-current="page">address</li></ul>';
         $this->assertEquals($string, $breadcrumbsHelper->render());
     }
 
-    /**
-     * @depends     testInitBreadcrumbs
-     * @param       Breadcrumbs     $breadcrumbs
-     * @return      void
-     */
-    public function testRenderWithOrderedListTag(Breadcrumbs $breadcrumbs)
+    public function testRenderWithOrderedListTag(): void
     {
-        $breadcrumbsHelper = new BreadcrumbsHelper($breadcrumbs);
+        $breadcrumbsHelper = new BreadcrumbsHelper($this->breadcrumbs);
         $breadcrumbsHelper->setTag('ol');
 
-        $string = '<ol><li><a href="/home/">home</a></li><li><a href="/profile/">profile</a></li><li>address</li></ol>';
+        $string = '<ol><li><a href="/home/">home</a></li><li><a href="/profile/">profile</a></li><li aria-current="page">address</li></ol>';
         $this->assertEquals($string, $breadcrumbsHelper->render());
     }
 
-    /**
-     * @depends     testInitBreadcrumbs
-     * @param       Breadcrumbs     $breadcrumbs
-     * @return      void
-     */
-    public function testRenderWithUnorderedListTagAndAttributes(Breadcrumbs $breadcrumbs)
+    public function testRenderWithUnorderedListTagAndAttributes(): void
     {
-        $breadcrumbsHelper = new BreadcrumbsHelper($breadcrumbs);
+        $breadcrumbsHelper = new BreadcrumbsHelper($this->breadcrumbs);
         $breadcrumbsHelper->setTag('ul');
         $breadcrumbsHelper->setOptions(array('id' => 'breadcrumb', 'class' => 'breadcrumbs'));
 
-        $string = '<ul id="breadcrumb" class="breadcrumbs"><li><a href="/home/">home</a></li><li><a href="/profile/">profile</a></li><li>address</li></ul>';
+        $string = '<ul id="breadcrumb" class="breadcrumbs"><li><a href="/home/">home</a></li><li><a href="/profile/">profile</a></li><li aria-current="page">address</li></ul>';
         $this->assertEquals($string, $breadcrumbsHelper->render());
     }
 
-    /**
-     * @depends     testInitBreadcrumbs
-     * @param       Breadcrumbs     $breadcrumbs
-     * @return      void
-     */
-    public function testRenderWithOrderedListTagAndAttributes(Breadcrumbs $breadcrumbs)
+    public function testRenderWithOrderedListTagAndAttributes(): void
     {
-        $breadcrumbsHelper = new BreadcrumbsHelper($breadcrumbs);
+        $breadcrumbsHelper = new BreadcrumbsHelper($this->breadcrumbs);
         $breadcrumbsHelper->setTag('ol');
         $breadcrumbsHelper->setOptions(array('id' => 'breadcrumb', 'class' => 'breadcrumbs'));
 
-        $string = '<ol id="breadcrumb" class="breadcrumbs"><li><a href="/home/">home</a></li><li><a href="/profile/">profile</a></li><li>address</li></ol>';
+        $string = '<ol id="breadcrumb" class="breadcrumbs"><li><a href="/home/">home</a></li><li><a href="/profile/">profile</a></li><li aria-current="page">address</li></ol>';
         $this->assertEquals($string, $breadcrumbsHelper->render());
     }
 
-    /**
-     * @depends     testInitBreadcrumbs
-     * @param       Breadcrumbs     $breadcrumbs
-     * @return      void
-     */
-    public function testRenderReverse(Breadcrumbs $breadcrumbs)
+    public function testRenderReverse(): void
     {
-        $breadcrumbsHelper = new BreadcrumbsHelper($breadcrumbs);
+        $breadcrumbsHelper = new BreadcrumbsHelper($this->breadcrumbs);
         $breadcrumbsHelper->setReverse(true);
 
         $string = 'address<a href="/profile/">profile</a><a href="/home/">home</a>';
         $this->assertEquals($string, $breadcrumbsHelper->render());
     }
 
-    /**
-     * @depends     testInitBreadcrumbs
-     * @param       Breadcrumbs     $breadcrumbs
-     * @return      void
-     */
-    public function testRenderReverseWithSeparator(Breadcrumbs $breadcrumbs)
+    public function testRenderReverseWithSeparator(): void
     {
-        $breadcrumbsHelper = new BreadcrumbsHelper($breadcrumbs);
+        $breadcrumbsHelper = new BreadcrumbsHelper($this->breadcrumbs);
         $breadcrumbsHelper->setSeparator(' / ');
         $breadcrumbsHelper->setReverse(true);
 
@@ -184,121 +141,81 @@ class BreadcrumbsHelperTest extends TestCase
         $this->assertEquals($string, $breadcrumbsHelper->render());
     }
 
-    /**
-     * @depends     testInitBreadcrumbs
-     * @param       Breadcrumbs     $breadcrumbs
-     * @return      void
-     */
-    public function testRenderReverseWithSpanTag(Breadcrumbs $breadcrumbs)
+    public function testRenderReverseWithSpanTag(): void
     {
-        $breadcrumbsHelper = new BreadcrumbsHelper($breadcrumbs);
+        $breadcrumbsHelper = new BreadcrumbsHelper($this->breadcrumbs);
         $breadcrumbsHelper->setReverse(true);
         $breadcrumbsHelper->setTag('span');
 
-        $string = '<span>address</span><span><a href="/profile/">profile</a></span><span><a href="/home/">home</a></span>';
+        $string = '<span aria-current="page">address</span><span><a href="/profile/">profile</a></span><span><a href="/home/">home</a></span>';
         $this->assertEquals($string, $breadcrumbsHelper->render());
     }
 
-    /**
-     * @depends     testInitBreadcrumbs
-     * @param       Breadcrumbs     $breadcrumbs
-     * @return      void
-     */
-    public function testRenderReverseWithDivTag(Breadcrumbs $breadcrumbs)
+    public function testRenderReverseWithDivTag(): void
     {
-        $breadcrumbsHelper = new BreadcrumbsHelper($breadcrumbs);
+        $breadcrumbsHelper = new BreadcrumbsHelper($this->breadcrumbs);
         $breadcrumbsHelper->setReverse(true);
         $breadcrumbsHelper->setTag('div');
 
-        $string = '<div>address</div><div><a href="/profile/">profile</a></div><div><a href="/home/">home</a></div>';
+        $string = '<div aria-current="page">address</div><div><a href="/profile/">profile</a></div><div><a href="/home/">home</a></div>';
         $this->assertEquals($string, $breadcrumbsHelper->render());
     }
 
-    /**
-     * @depends     testInitBreadcrumbs
-     * @param       Breadcrumbs     $breadcrumbs
-     * @return      void
-     */
-    public function testRenderReverseWithListItemTag(Breadcrumbs $breadcrumbs)
+    public function testRenderReverseWithListItemTag(): void
     {
-        $breadcrumbsHelper = new BreadcrumbsHelper($breadcrumbs);
+        $breadcrumbsHelper = new BreadcrumbsHelper($this->breadcrumbs);
         $breadcrumbsHelper->setReverse(true);
         $breadcrumbsHelper->setTag('li');
 
-        $string = '<li>address</li><li><a href="/profile/">profile</a></li><li><a href="/home/">home</a></li>';
+        $string = '<li aria-current="page">address</li><li><a href="/profile/">profile</a></li><li><a href="/home/">home</a></li>';
         $this->assertEquals($string, $breadcrumbsHelper->render());
     }
 
-    /**
-     * @depends     testInitBreadcrumbs
-     * @param       Breadcrumbs     $breadcrumbs
-     * @return      void
-     */
-    public function testRenderReverseWithUnorderedListTag(Breadcrumbs $breadcrumbs)
+    public function testRenderReverseWithUnorderedListTag(): void
     {
-        $breadcrumbsHelper = new BreadcrumbsHelper($breadcrumbs);
+        $breadcrumbsHelper = new BreadcrumbsHelper($this->breadcrumbs);
         $breadcrumbsHelper->setReverse(true);
         $breadcrumbsHelper->setTag('ul');
 
-        $string = '<ul><li>address</li><li><a href="/profile/">profile</a></li><li><a href="/home/">home</a></li></ul>';
+        $string = '<ul><li aria-current="page">address</li><li><a href="/profile/">profile</a></li><li><a href="/home/">home</a></li></ul>';
         $this->assertEquals($string, $breadcrumbsHelper->render());
     }
 
-    /**
-     * @depends     testInitBreadcrumbs
-     * @param       Breadcrumbs     $breadcrumbs
-     * @return      void
-     */
-    public function testRenderReverseWithOrderedListTag(Breadcrumbs $breadcrumbs)
+    public function testRenderReverseWithOrderedListTag(): void
     {
-        $breadcrumbsHelper = new BreadcrumbsHelper($breadcrumbs);
+        $breadcrumbsHelper = new BreadcrumbsHelper($this->breadcrumbs);
         $breadcrumbsHelper->setReverse(true);
         $breadcrumbsHelper->setTag('ol');
 
-        $string = '<ol><li>address</li><li><a href="/profile/" aria-current="page">profile</a></li><li><a href="/home/">home</a></li></ol>';
+        $string = '<ol><li aria-current="page">address</li><li><a href="/profile/">profile</a></li><li><a href="/home/">home</a></li></ol>';
         $this->assertEquals($string, $breadcrumbsHelper->render());
     }
 
-    /**
-     * @depends     testInitBreadcrumbs
-     * @param       Breadcrumbs     $breadcrumbs
-     * @return      void
-     */
-    public function testRenderReverseWithUnorderedListTagAndAttributes(Breadcrumbs $breadcrumbs)
+    public function testRenderReverseWithUnorderedListTagAndAttributes(): void
     {
-        $breadcrumbsHelper = new BreadcrumbsHelper($breadcrumbs);
+        $breadcrumbsHelper = new BreadcrumbsHelper($this->breadcrumbs);
         $breadcrumbsHelper->setReverse(true);
         $breadcrumbsHelper->setTag('ul');
         $breadcrumbsHelper->setOptions(array('id' => 'breadcrumb', 'class' => 'breadcrumbs'));
 
-        $string = '<ul id="breadcrumb" class="breadcrumbs"><li>address</li><li><a href="/profile/">profile</a></li><li><a href="/home/">home</a></li></ul>';
+        $string = '<ul id="breadcrumb" class="breadcrumbs"><li aria-current="page">address</li><li><a href="/profile/">profile</a></li><li><a href="/home/">home</a></li></ul>';
         $this->assertEquals($string, $breadcrumbsHelper->render());
     }
 
-    /**
-     * @depends     testInitBreadcrumbs
-     * @param       Breadcrumbs     $breadcrumbs
-     * @return      void
-     */
-    public function testRenderReverseWithOrderedListTagAndAttributes(Breadcrumbs $breadcrumbs)
+    public function testRenderReverseWithOrderedListTagAndAttributes(): void
     {
-        $breadcrumbsHelper = new BreadcrumbsHelper($breadcrumbs);
+        $breadcrumbsHelper = new BreadcrumbsHelper($this->breadcrumbs);
         $breadcrumbsHelper->setReverse(true);
         $breadcrumbsHelper->setTag('ol');
         $breadcrumbsHelper->setOptions(array('id' => 'breadcrumb', 'class' => 'breadcrumbs'));
 
-        $string = '<ol id="breadcrumb" class="breadcrumbs"><li>address</li><li><a href="/profile/">profile</a></li><li><a href="/home/">home</a></li></ol>';
+        $string = '<ol id="breadcrumb" class="breadcrumbs"><li aria-current="page">address</li><li><a href="/profile/">profile</a></li><li><a href="/home/">home</a></li></ol>';
         $this->assertEquals($string, $breadcrumbsHelper->render());
     }
 
-    /**
-     * @depends     testInitBreadcrumbs
-     * @param       Breadcrumbs     $breadcrumbs
-     * @return      void
-     */
-    public function testRenderWithoutLinks(Breadcrumbs $breadcrumbs)
+    public function testRenderWithoutLinks(): void
     {
-        $breadcrumbsHelper = new BreadcrumbsHelper($breadcrumbs);
+        $breadcrumbsHelper = new BreadcrumbsHelper($this->breadcrumbs);
         $breadcrumbsHelper->setSkipLinks(true);
         $breadcrumbsHelper->setSeparator(' / ');
 
@@ -306,14 +223,9 @@ class BreadcrumbsHelperTest extends TestCase
         $this->assertEquals($string, $breadcrumbsHelper->render());
     }
 
-    /**
-     * @depends     testInitBreadcrumbs
-     * @param       Breadcrumbs     $breadcrumbs
-     * @return      void
-     */
-    public function testRenderReverseWithoutLinks(Breadcrumbs $breadcrumbs)
+    public function testRenderReverseWithoutLinks(): void
     {
-        $breadcrumbsHelper = new BreadcrumbsHelper($breadcrumbs);
+        $breadcrumbsHelper = new BreadcrumbsHelper($this->breadcrumbs);
         $breadcrumbsHelper->setReverse(true);
         $breadcrumbsHelper->setSkipLinks(true);
         $breadcrumbsHelper->setSeparator(' / ');

--- a/tests/BreadcrumbsHelperTest.php
+++ b/tests/BreadcrumbsHelperTest.php
@@ -47,6 +47,20 @@ class BreadcrumbsHelperTest extends TestCase
         $this->assertEquals($string, $breadcrumbsHelper->render());
     }
 
+    public function testRenderIfLastElementIsLink(): void
+    {
+        $testBreadcrumbs = new Breadcrumbs();
+        $testBreadcrumbs->add('home', '/home/');
+        $testBreadcrumbs->add('profile', '/profile/');
+        $testBreadcrumbs->add('address', '/address/');
+
+        $breadcrumbsHelper = new BreadcrumbsHelper($testBreadcrumbs);
+        $breadcrumbsHelper->setTag('ul');
+
+        $string = '<ul><li><a href="/home/">home</a></li><li><a href="/profile/">profile</a></li><li><a href="/address/" aria-current="page">address</a></li></ul>';
+        $this->assertEquals($string, $breadcrumbsHelper->render());
+    }
+
     public function testRenderWithSeparator(): void
     {
         $breadcrumbsHelper = new BreadcrumbsHelper($this->breadcrumbs);

--- a/tests/BreadcrumbsTest.php
+++ b/tests/BreadcrumbsTest.php
@@ -11,8 +11,9 @@ namespace Naucon\Breadcrumbs\Tests;
 
 use Naucon\Breadcrumbs\Breadcrumbs;
 use Naucon\Breadcrumbs\BreadcrumbsInterface;
+use PHPUnit\Framework\TestCase;
 
-class BreadcrumbsTest extends \PHPUnit_Framework_TestCase
+class BreadcrumbsTest extends TestCase
 {
     /**
      * @return      BreadcrumbsInterface

--- a/tests/BreadcrumbsTest.php
+++ b/tests/BreadcrumbsTest.php
@@ -16,48 +16,41 @@ use PHPUnit\Framework\TestCase;
 class BreadcrumbsTest extends TestCase
 {
     /**
-     * @return      BreadcrumbsInterface
+     * @param Breadcrumbs $breadcrumbs
      */
-    public function testInit()
-    {
-        $breadcrumbs = new Breadcrumbs();
-        return $breadcrumbs;
-    }
+    private $breadcrumbs;
 
     /**
-     * @depends     testInit
-     * @param       BreadcrumbsInterface        $breadcrumbs
-     * @return      BreadcrumbsInterface
+     * @param Breadcrumbs $fluentInterfaceBreadcrumbs
      */
-    public function testAdd(BreadcrumbsInterface $breadcrumbs)
-    {
-        $breadcrumbs->add('home', '/home/');
-        $breadcrumbs->add('profile', '/profile/');
-        $breadcrumbs->add('address');
+    private $fluentInterfaceBreadcrumbs;
 
-        return $breadcrumbs;
+    public function setup(): void
+    {
+        $this->breadcrumbs = new Breadcrumbs();
+        $this->prepareBreadcrumbs();
     }
 
-    /**
-     * @depends     testAdd
-     * @param       BreadcrumbsInterface        $breadcrumbs
-     * @return      BreadcrumbsInterface
-     */
-    public function testCount(BreadcrumbsInterface $breadcrumbs)
+    public function tearDown(): void
     {
-        $this->assertEquals(3, $breadcrumbs->count());
-
-        return $breadcrumbs;
+        $this->breadcrumbs->clear();
     }
 
-    /**
-     * @depends     testAdd
-     * @param       BreadcrumbsInterface        $breadcrumbs
-     * @return      BreadcrumbsInterface
-     */
-    public function testIterator(BreadcrumbsInterface $breadcrumbs)
+    public function prepareBreadcrumbs(): void
     {
-        $breadcrumbIterator = $breadcrumbs->getIterator();
+        $this->breadcrumbs->add('home', '/home/');
+        $this->breadcrumbs->add('profile', '/profile/');
+        $this->breadcrumbs->add('address');
+    }
+
+    public function testCount(): void
+    {
+        $this->assertEquals(3, $this->breadcrumbs->count());
+    }
+
+    public function testIterator(): void
+    {
+        $breadcrumbIterator = $this->breadcrumbs->getIterator();
 
         $expectedBreadcrumbs = array();
         $expectedBreadcrumbs[0]['title'] = 'home';
@@ -75,18 +68,11 @@ class BreadcrumbsTest extends TestCase
             $i++;
         }
         $this->assertEquals(3, $i);
-
-        return $breadcrumbs;
     }
 
-    /**
-     * @depends     testAdd
-     * @param       BreadcrumbsInterface        $breadcrumbs
-     * @return      BreadcrumbsInterface
-     */
-    public function testReverseIterator(BreadcrumbsInterface $breadcrumbs)
+    public function testReverseIterator(): void
     {
-        $breadcrumbIterator = $breadcrumbs->getReverseIterator();
+        $breadcrumbIterator = $this->breadcrumbs->getReverseIterator();
 
         $expectedBreadcrumbs = array();
         $expectedBreadcrumbs[0]['title'] = 'address';
@@ -104,60 +90,37 @@ class BreadcrumbsTest extends TestCase
             $i++;
         }
         $this->assertEquals(3, $i);
-
-        return $breadcrumbs;
     }
 
-    /**
-     * @depends     testAdd
-     * @param       BreadcrumbsInterface        $breadcrumbs
-     * @return      BreadcrumbsInterface
-     */
-    public function testClear(BreadcrumbsInterface $breadcrumbs)
+    public function testClear(): void
     {
-        $this->assertEquals(3, $breadcrumbs->count());
+        $this->assertEquals(3, $this->breadcrumbs->count());
 
-        $breadcrumbs->clear();
+        $this->breadcrumbs->clear();
 
-        $this->assertEquals(0, $breadcrumbs->count());
-
-        return $breadcrumbs;
+        $this->assertEquals(0, $this->breadcrumbs->count());
     }
 
-    /**
-     * @return      BreadcrumbsInterface
-     */
-    public function testAddWithFluentInterface()
+    public function prepareBreadcrumbsWithFluentInterface(): void
     {
-        $breadcrumbs = new Breadcrumbs();
+        $this->fluentInterfaceBreadcrumbs = new Breadcrumbs();
 
-        $breadcrumbs->add('home', '/home/')
+        $this->fluentInterfaceBreadcrumbs->add('home', '/home/')
             ->add('profile', '/profile/')
             ->add('address');
-
-        return $breadcrumbs;
     }
 
-    /**
-     * @depends     testAddWithFluentInterface
-     * @param       BreadcrumbsInterface        $breadcrumbs
-     * @return      BreadcrumbsInterface
-     */
-    public function testCountWithFluentInterface(BreadcrumbsInterface $breadcrumbs)
+    public function testCountWithFluentInterface(): void
     {
-        $this->assertEquals(3, $breadcrumbs->count());
-
-        return $breadcrumbs;
+        $this->prepareBreadcrumbsWithFluentInterface();
+        $this->assertEquals(3, $this->fluentInterfaceBreadcrumbs->count());
+        $this->fluentInterfaceBreadcrumbs->clear();
     }
 
-    /**
-     * @depends     testAddWithFluentInterface
-     * @param       BreadcrumbsInterface        $breadcrumbs
-     * @return      BreadcrumbsInterface
-     */
-    public function testIteratorWithFluentInterface(BreadcrumbsInterface $breadcrumbs)
+    public function testIteratorWithFluentInterface(): void
     {
-        $breadcrumbIterator = $breadcrumbs->getIterator();
+        $this->prepareBreadcrumbsWithFluentInterface();
+        $breadcrumbIterator = $this->fluentInterfaceBreadcrumbs->getIterator();
 
         $expectedBreadcrumbs = array();
         $expectedBreadcrumbs[0]['title'] = 'home';
@@ -175,7 +138,6 @@ class BreadcrumbsTest extends TestCase
             $i++;
         }
         $this->assertEquals(3, $i);
-
-        return $breadcrumbs;
+        $this->fluentInterfaceBreadcrumbs->clear();
     }
 }


### PR DESCRIPTION
This pull request introduces the addition of the aria-current="page" attribute to the active link in the breadcrumb navigation. This change is in compliance with the BFSG (Barrierefreiheitsstärkungsgesetz) Law, which mandates accessibility improvements for digital services.

The aria-current="page" attribute is a critical accessibility feature that aids screen readers in identifying the current page within a set of breadcrumbs. By explicitly marking the active breadcrumb, we enhance the navigational experience for users relying on assistive technologies, making our application more inclusive.